### PR TITLE
update grid polygon overlay

### DIFF
--- a/Sources/GeoJSONSwiftHelper/GridHelper.swift
+++ b/Sources/GeoJSONSwiftHelper/GridHelper.swift
@@ -218,7 +218,7 @@ public struct GridHelper {
   public class GridPolygonOverlay: MKPolygon, Identifiable, Comparable {
     public var id: String = UUID().uuidString
     public let isGrid: Bool = true
-    public var boundary: [Turf.Polygon]? = nil
+    public var boundary: Turf.MultiPolygon? = nil
     public var selected = false
 
     public var opacity: Double {
@@ -230,7 +230,7 @@ public struct GridHelper {
     public var geoJSON: String {
       guard let boundary = boundary else { return "" }
 
-      let geoObj = Turf.MultiPolygon(boundary)
+      let geoObj = boundary
       var feature = Turf.Feature(geometry: geoObj)
       feature.properties = JSONObject(rawValue: ["id": id])
 
@@ -245,7 +245,7 @@ public struct GridHelper {
     public static func create(_ geoJSONObj: GeoJSONObject, selected: Bool = false) -> GridPolygonOverlay {
       let polygon = GridPolygonOverlay()
       polygon.selected = selected
-      polygon.boundary = geoJSONObj.polygons
+      polygon.boundary = geoJSONObj.multipolygons
       return polygon
     }
 
@@ -266,7 +266,8 @@ public struct GridHelper {
       let jsonDecoder = JSONDecoder()
       let jsonEncoder = JSONEncoder()
       do  {
-        let cellData = try jsonEncoder.encode(self.boundary)
+        guard let boundary = self.boundary else { return nil }
+        let cellData = try jsonEncoder.encode(boundary)
         let cellGeoJSONObj = try jsonDecoder.decode(GEOSwift.GeoJSON.self, from: cellData)
         if let boundaryData = boundaryGeoJSON.data(using: .utf8) {
           let boundaryGeoJSONObj = try jsonDecoder.decode(GEOSwift.GeoJSON.self, from: boundaryData)

--- a/Sources/GeoJSONSwiftHelper/GridHelper.swift
+++ b/Sources/GeoJSONSwiftHelper/GridHelper.swift
@@ -266,6 +266,7 @@ public struct GridHelper {
       let jsonDecoder = JSONDecoder()
       let jsonEncoder = JSONEncoder()
       do  {
+        /// 1. Convert boundary and cell polygon to GEOSwift Geometries
         guard let boundary = self.boundary else { return nil }
         let cellData = try jsonEncoder.encode(boundary)
         let cellGeoJSONObj = try jsonDecoder.decode(GEOSwift.GeoJSON.self, from: cellData)
@@ -283,7 +284,6 @@ public struct GridHelper {
           case .geometry(let geometry):
             boundaryGeometries = [geometry]
           }
-
           boundaryGeometries.forEach { boundaryGeometry in
             /// 2. Find intersection
             if let boundaryGeometry = boundaryGeometry {
@@ -298,7 +298,6 @@ public struct GridHelper {
               }
             }
           }
-
           /// 3. Convert intersection geometry to a GridPolygonOverlay
           ///
           ///
@@ -310,10 +309,9 @@ public struct GridHelper {
           newOverlay.selected = true
           return newOverlay
           }
-
         }
       } catch {
-        print(error.localizedDescription)
+        print(String(describing: error))
       }
       return nil
     }

--- a/Sources/GeoJSONSwiftHelper/GridHelper.swift
+++ b/Sources/GeoJSONSwiftHelper/GridHelper.swift
@@ -199,9 +199,8 @@ public struct GridHelper {
   }
 
   public class GridPolygonOverlay: MKPolygon, Identifiable, Comparable {
-    public var id = UUID()
-    let isGrid = true
-
+    public var id: String = UUID().uuidString
+    public let isGrid: Bool = true
     public var boundary: Turf.Polygon? = nil
     public var selected = false
 
@@ -216,7 +215,7 @@ public struct GridHelper {
 
       let geoObj = Turf.Geometry(boundary)
       var feature = Turf.Feature(geometry: geoObj)
-      feature.properties = JSONObject(rawValue: ["id": id.uuidString])
+      feature.properties = JSONObject(rawValue: ["id": id])
 
       if let geoData = try? JSONEncoder().encode(feature),
          let geoString = String(data: geoData, encoding: .utf8) {


### PR DESCRIPTION
- Updated grid polygon overlay to support multi polygon.
- Changed field types for GridPolygonOverlay
 `id` => ` UUID` -> `String`,
 `boundary` => `Turf.Polygon?` -> `Turf.MultiPolygon`
- Added `multipolygons` variable to get the `Turf.Multipolygon` by using `getMultiPolygons` method in the GEOJSONObject extension. 
- Refactored codebase.